### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/Beetle.EntityFrameworkCore/Beetle.EntityFrameworkCore.csproj
+++ b/src/Beetle.EntityFrameworkCore/Beetle.EntityFrameworkCore.csproj
@@ -14,7 +14,15 @@
     <RepositoryUrl>https://github.com/umutozel/Beetle</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.3" />

--- a/src/Beetle.Meta/Beetle.Meta.csproj
+++ b/src/Beetle.Meta/Beetle.Meta.csproj
@@ -14,6 +14,14 @@
     <RepositoryUrl>https://github.com/umutozel/Beetle</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 </Project>

--- a/src/Beetle.MvcCore/Beetle.MvcCore.csproj
+++ b/src/Beetle.MvcCore/Beetle.MvcCore.csproj
@@ -13,7 +13,15 @@
     <PackageTags>Beetle js Unit of Work Client Side Change Tracker Asp.Net Mvc Core</PackageTags>
     <RepositoryUrl>https://github.com/umutozel/Beetle</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup>
     <DefineConstants>MVC_CORE</DefineConstants>

--- a/src/Beetle.MvcCoreApi/Beetle.MvcCoreApi.csproj
+++ b/src/Beetle.MvcCoreApi/Beetle.MvcCoreApi.csproj
@@ -13,7 +13,15 @@
     <PackageTags>Beetle js Unit of Work Client Side Change Tracker Asp.Net Mvc Core</PackageTags>
     <RepositoryUrl>https://github.com/umutozel/Beetle</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup>
     <DefineConstants>MVC_CORE_API</DefineConstants>

--- a/src/Beetle.Server/Beetle.Server.csproj
+++ b/src/Beetle.Server/Beetle.Server.csproj
@@ -13,7 +13,15 @@
     <PackageTags>Beetle js Unit of Work Client Side Change Tracker</PackageTags>
     <RepositoryUrl>https://github.com/umutozel/Beetle</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>NET_STANDARD</DefineConstants>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
